### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Terminal MCP Server
 [![smithery badge](https://smithery.ai/badge/@weidwonder/terminal-mcp-server)](https://smithery.ai/server/@weidwonder/terminal-mcp-server)
 
+<a href="https://glama.ai/mcp/servers/@weidwonder/terminal-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@weidwonder/terminal-mcp-server/badge" alt="Terminal Server MCP server" />
+</a>
+
 *[中文文档](README_CN.md)*
 
 Terminal MCP Server is a Model Context Protocol (MCP) server that allows executing commands on local or remote hosts. It provides a simple yet powerful interface for AI models and other applications to execute system commands, either on the local machine or on remote hosts via SSH.


### PR DESCRIPTION
This PR adds a badge for the [Terminal MCP Server](https://glama.ai/mcp/servers/@weidwonder/terminal-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@weidwonder/terminal-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@weidwonder/terminal-mcp-server/badge" alt="Terminal Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.